### PR TITLE
Bump to 0.8.1

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,5 +1,5 @@
 {% set name = "mistune" %}
-{% set version = "0.8" %}
+{% set version = "0.8.1" %}
 
 package:
   name: {{ name }}
@@ -7,7 +7,7 @@ package:
 
 source:
   url: https://pypi.io/packages/source/{{ name[0] }}/{{ name }}/{{ name }}-{{ version }}.tar.gz
-  sha256: dc3f43e7cf0abb95cdfecbf82d85c419108d5f13e1844b2a8a2fc0abf24c7a47
+  sha256: 4c0f66924ce28f03b95b210ea57e57bd0b59f479edd91c2fa4fe59331eae4a82
 
 build:
   number: 0


### PR DESCRIPTION
Bump to the just-released 0.8.1.

Appears to be a (mostly) one-liner change:
```
├── mistune.py
│ @@ -7,15 +7,15 @@
│
│      :copyright: (c) 2014 - 2017 by Hsiaoming Yang.
│  """
│
│  import re
│  import inspect
│
│ -__version__ = '0.8'
│ +__version__ = '0.8.1'
│  __author__ = 'Hsiaoming Yang <me@lepture.com>'
│  __all__ = [
│      'BlockGrammar', 'BlockLexer',
│      'InlineGrammar', 'InlineLexer',
│      'Renderer', 'Markdown',
│      'markdown', 'escape',
│  ]
│ @@ -44,15 +44,15 @@
│      pattern = regex.pattern
│      if pattern.startswith('^'):
│          pattern = pattern[1:]
│      return pattern
│
│
│  def _keyify(key):
│ -    return _key_pattern.sub(' ', key.lower())
│ +    return _key_pattern.sub(' ', escape(key, quote=True))
```

But usually I like getting the most recent escaping changes :)

Causing some hair-pulling, this change doesn't appear in the [source](https://github.com/lepture/mistune/blob/master/mistune.py#L51)...
