### PR TITLE
add run_constrained for nbconvert

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
 
 build:
   noarch: python
-  number: 0
+  number: 1
   script: {{ PYTHON }} -m pip install . --no-deps -vv
 
 requirements:
@@ -19,6 +19,10 @@ requirements:
     - pip
   run:
     - python >=2.7
+  run_constrained:
+    # 6.1.0 pins to mistune <2 (a future version may loosen this pin)
+    # see: https://github.com/conda-forge/nbconvert-feedstock/pull/54
+    - nbconvert >6.1.0
 
 test:
   source_files:


### PR DESCRIPTION
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

Changes:
- adds a (currently unsatisfiable) `run_constrained` to `nbconvert 6.1.0` (what adds a pin to `mistune <2`)
 - presumably we'll [figure something out upstream](https://github.com/jupyter/nbconvert/issues/1685) but it's not actively _breaking_ anything, so long as we _don't_ have it installed

Related:
- https://github.com/conda-forge/nbconvert-feedstock/pull/54#issuecomment-988281959